### PR TITLE
Fix day6-f#

### DIFF
--- a/day6-fsharp/Program.fs
+++ b/day6-fsharp/Program.fs
@@ -32,7 +32,7 @@ let evolve population =
 
     population
     |> Seq.map (fun p -> {
-        Age = if p.Age > FishAge 0 then p.Age - FishAge 1 else FishAge 6
+        Age = if p.Age > FishAge.Zero then p.Age - FishAge 1 else FishAge 6
         Size = p.Size;
     })
     |> Seq.insertAt 0 newFish

--- a/day6-fsharp/Program.fs
+++ b/day6-fsharp/Program.fs
@@ -1,35 +1,52 @@
-﻿open System.IO
-type FishAge = FishAge of int32
-type PopulationSize = PopulationSize of int64
+open System.IO
+
+type FishAge = FishAge of int32 with
+    static member Zero = FishAge 0
+    static member (-) (FishAge a, FishAge b) = FishAge (a - b)
+
+type PopulationSize = PopulationSize of int64 with
+    static member Zero = PopulationSize 0L
+    static member (+) (PopulationSize a, PopulationSize b) = PopulationSize (a + b)
+
 type PopulationSegment = { Age: FishAge; Size: PopulationSize }
 
 let tokens = File.ReadAllText("input.txt").Split(',')
-let population = 
-    tokens
-    |> Seq.map int32    
-    |> Seq.groupBy (fun age -> age)
-    |> Seq.map (fun group -> 
-        let age = fst group
-        let size = snd group |> Seq.length
-        { Age = FishAge age; Size = PopulationSize size })
 
-let evolve population = 
-    let fishAboutToSpawn = population |> Seq.tryFind (fun p -> p.Age = 0)
-    let newFish = { Age = 8; Size = if fishAboutToSpawn.IsNone then 0 else fishAboutToSpawn.Value.Size }    
-    population 
-    |> Seq.map (fun p -> { Age = (if p.Age > 0 then p.Age - 1 else 6); Size = p.Size; })
+let population =
+    tokens
+    |> Seq.map int32
+    |> Seq.groupBy id
+    |> Seq.map (fun group ->
+        let age = fst group
+        let size = snd group |> Seq.length |> int64
+        { Age = FishAge age; Size = PopulationSize size }
+    )
+
+let evolve population =
+    let fishAboutToSpawn = population |> Seq.tryFind (fun p -> p.Age = FishAge.Zero)
+
+    let newFish = {
+        Age = FishAge 8
+        Size = fishAboutToSpawn |> Option.map (fun p -> p.Size) |> Option.defaultValue PopulationSize.Zero
+    }
+
+    population
+    |> Seq.map (fun p -> {
+        Age = if p.Age > FishAge 0 then p.Age - FishAge 1 else FishAge 6
+        Size = p.Size;
+    })
     |> Seq.insertAt 0 newFish
     |> Seq.groupBy (fun popn -> popn.Age)
-    |> Seq.map (fun group -> 
+    |> Seq.map (fun group ->
         let age = fst group
-        let size = snd group |> Seq.map (fun p -> p.Size) |> Seq.sum |> PopulationSize 
+        let size = snd group |> Seq.map (fun p -> p.Size) |> Seq.sum
         { Age = age; Size = size })
 
-let rec solve days population = 
-    if days = 0 then 
-        population |> Seq.map (fun pair -> pair.Size) |> Seq.sum 
+let rec solve days population =
+    if days = 0 then
+        population |> Seq.map (fun pair -> pair.Size) |> Seq.sum
     else
         solve (days-1) (evolve population)
-    
-printfn "Part1: %i" (solve 80 population)
-printfn "Part 2: %i" (solve 256 population)
+
+printfn $"Part 1: {solve 80 population}"
+printfn $"Part 2: {solve 256 population}"


### PR DESCRIPTION
One of the ways to do it.

Some notes:
- Defining a member `Zero` and `+` operator on a type allows it to be consumed by `Seq.sum`
- When dealing with `Option a'` (like `fishAboutToSpawn`), you should either use pattern matching (`fishAboutToSpawn match with ...`) or functions on `Option`. In this case we can unwrap the option by mapping it to `p.Size` and giving a default value.
- Arithmetic operations do require defining the operators on the type, which makes it a bit annoying. Also you have to write `FishAge` everywhere when comparing it to numbers. An alternative would be to define an `unwrap` function for the type to map it back to `int32`, but that would just be the same issue backwards.
- In real-life scenarios, you would define transform functions on `FishAge` and `PopulationSize`, such as `FishAge.isAlive` (to replace `p.Age > FishAge 0`) or `FishAge.decrement` (to replace `p.Age - FishAge 1`). I don't know enough about the problem to suggest what would be a similar treatment here.

Also, you can take a look at units of measurement as an alternative way of defining types based on numeric primitives: https://paul.blasuc.ci/posts/really-scu.html
That way you won't have to redefine arithmetics.